### PR TITLE
ini_file 'create' parameter default value should be True

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -148,7 +148,7 @@ def match_active_opt(option, line):
 # do_ini
 
 def do_ini(module, filename, section=None, option=None, value=None,
-        state='present', backup=False, no_extra_spaces=False, create=False):
+        state='present', backup=False, no_extra_spaces=False, create=True):
 
     diff = {'before': '',
             'after': '',


### PR DESCRIPTION
Updated create default value to True to match documentation (and common sense).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - modules/files/ini_file

##### ANSIBLE VERSION
```
2.3.0 0.0.devel
```

##### SUMMARY
The Ansible [documentation](http://docs.ansible.com/ansible/ini_file_module.html) for ini_file says a new parameter called `create` was added in 2.2 and the default is `yes`:

```
  create:
     required: false
     choices: [ "yes", "no" ]
     default: "yes"
     description:
       - If set to 'no', the module will fail if the file does not already exist.
         By default it will create the file if it is missing.
     version_added: "2.2"
```

However the function declaration defaults the `create` variable to `False` which means existing calls to `ini_file` no longer function as per the documentation, nor as expected.
